### PR TITLE
Fixes authorization header not being supplied

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,10 @@ exports.register  = function(server, options, next) {
         if (request._route.settings && request._route.settings.plugins && request._route.settings.plugins.cognito) {
             var routeConfig = request._route.settings.plugins.cognito;
 
-            var decoded = jwt.decode(request.headers.authorization.replace('Bearer ', ''));
+            var decoded = null;
+            if (request.headers.authorization) {
+                decoded = jwt.decode(request.headers.authorization.replace('Bearer ', ''));
+            }
             if (pluginConfig.debug) console.log("decoded jwt token", decoded);
 
             if (decoded === null && routeConfig.required==false) {


### PR DESCRIPTION
Enables normal pass before the replace can blow up. Missed that case the first time around